### PR TITLE
Split the README.md

### DIFF
--- a/Archive/2020-21/README.md
+++ b/Archive/2020-21/README.md
@@ -1,0 +1,11 @@
+### Academic Year (2020 - 21) Events:
+* [Python Basics 1.0 Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/Python%20Workshop%201) - 21st October 2020
+* [Python Basics 2.0 Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/Python%20Workshop%202) - 4th November 2020
+* [IBM MTM Introduction Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/MTM%20Workshop) - 12th November 2020
+* [Design & Good Practice (C++) Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/C%2B%2B%20Good%20Practice) - 9th December 2020
+* [Python in Industry Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/Python%20in%20Industry) - 20th January 2021
+* [A World of Insecurity ft John Walker](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/World%20Of%20Insecurity) - 10th February 2021
+* [GitHub Basics Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/GitHub%20Basics%20Workshop) - 3rd March 2021
+* [Using GitHub with GIT CLI Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/GitHub%20Git%20CLI) - 10th March 2021
+* [C++ Support Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/C%2B%2B%20Workshop) - 17th March 2021
+* [Discord for Beginners Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2020-21/Discord%20For%20Beginners) - 24th March 2021

--- a/Archive/2021-22/README.md
+++ b/Archive/2021-22/README.md
@@ -1,0 +1,9 @@
+### Academic Year (2021 - 22) Events:
+* [Placements Q&A](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/Placements%20101%20QA) - 29th September 2021
+* [IBM Z Xplore (IRL)](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/IBM%20Z%20Xplore) - 24th October 2021
+* [Python Basics Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/Python%20Basics) - 27th October 2021
+* [HTML/CSS Q&A](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/HTML%26CSS%20QA) - 17th November 2021
+* [C++ Design & Good Practice Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/C%2B%2B%20Good%20Practices%20Workshop) - 1st December 2021
+* [GitHub Basics Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/Github%20Basics%20Workshop) - 26th January 2022
+* [Let's Make: [VS Code Extensions] Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/Lets%20Make%20VS%20Code%20Extension%20Workshop) - 9th March 2022
+* [C# Workshop](https://github.com/NTUDevSoc/Workshops/tree/main/Archive/2021-22/C#%20Basics%20Workshop) - 13th March 2022

--- a/Python Basics/WorkshopInformation.md
+++ b/Python Basics/WorkshopInformation.md
@@ -1,0 +1,4 @@
+# Python Basics Workshop
+The meeting recording for Jake's Python Workshop.
+
+[Recording](https://youtu.be/B9j-McCqP0M)


### PR DESCRIPTION
Better to have all the link details in each folder instead of the main page. Mostly future-proofing this early to save us the very long readme.md in a couple year's time.